### PR TITLE
Import ui-base-theme styles inside theme

### DIFF
--- a/addon/styles/components/tomato--ui-button--default.scss
+++ b/addon/styles/components/tomato--ui-button--default.scss
@@ -1,3 +1,8 @@
+@import "ui-base-theme/components/ui-button--default";
+
 @component {
-  background: tomato;
+  @include ui-button--default(
+    $background: tomato,
+    $color: white
+  );
 }

--- a/addon/styles/ui-tomato-theme.scss
+++ b/addon/styles/ui-tomato-theme.scss
@@ -1,2 +1,3 @@
-// TODO import ui-base-theme once the preprocessors will allow it
+@import 'ui-base-theme/ui-base-theme';
+
 @import './forms';

--- a/tests/dummy/app/styles/app.scss
+++ b/tests/dummy/app/styles/app.scss
@@ -2,5 +2,5 @@ body {
   padding: 10px;
   background: #f5f8f9;
 }
-@import 'ui-base-theme';
+
 @import 'ui-tomato-theme';


### PR DESCRIPTION
This
- imports the styles from ui-base-theme inside ui-tomato-theme instead of inside the dummy app
- Updates the `tomato--ui-button--default` component to make use of the `ui-button--default` mixin.
