### PR TITLE
Mount the styleguide route from ui-base-theme in dummy app

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
     "ember-cli-sri": "^2.1.0",
     "ember-cli-test-loader": "^1.1.0",
     "ember-cli-uglify": "^1.2.0",
+    "ember-code-snippet": "1.4.0",
     "ember-data": "^2.7.0-beta.1",
     "ember-disable-prototype-extensions": "^1.1.0",
     "ember-export-application-global": "^1.0.5",

--- a/tests/dummy/app/router.js
+++ b/tests/dummy/app/router.js
@@ -7,6 +7,7 @@ const Router = Ember.Router.extend({
 });
 
 Router.map(function() {
+  this.route('-ui-styleguide', { path: 'styleguide' });
 });
 
 export default Router;


### PR DESCRIPTION
Depends on https://github.com/prototypal-io/ui-base-theme/pull/15

This mounts the styleguide route from ui-base-theme at /styleguide.

This also adds ember-code-snippet as a dependency because there seem to
be some issues to work out when using it as a nested dependency.
